### PR TITLE
Add groupId and version in module pom

### DIFF
--- a/dox/pom.xml
+++ b/dox/pom.xml
@@ -3,6 +3,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
+    <groupId>com.xmldocumentationforaemaacs</groupId>
+    <version>0.0.1-SNAPSHOT</version>
 
     <parent>
         <groupId>com.xmldocumentationforaemaacs</groupId>


### PR DESCRIPTION
Hi,

I would recommend adding `groupId` and `version` to the `dox/pom.xml`

As per current instructions in your readme.md it mentions to update the parent section in `dox/pom.xml` with your projects parent section.

But one would also need to update parent section of `dox.installer/pom.xml` with projects pom details. If not the `dox.installer/pom.xml` throws


`parent.relativePath' of POM com.xmldocumentationforaemaacs:aemaacs-dox-project-dox-installer:0.0.1-SNAPSHOT (/Users/myuser/acrolinx-demo-wknd/dox/dox.installer/pom.xml) points at com.adobe.aem.guides:aemaacs-dox-project-dox-manager instead of com.xmldocumentationforaemaacs:aemaacs-dox-project-dox-manager, please verify your project structure`


Suggestion:

Specify to update parent section in both pom's `dox/pom.xml` and `dox.installer/pom.xml` in readme
OR
Update `dox/pom.xml` with your `groupId` and `version`

The pull request provides with the second approach.